### PR TITLE
[#33] [REFACTOR] 실시간 검색어 스케쥴링/ 캐싱 및 Shed Lock 적용

### DIFF
--- a/cercat-domain/domain-search/src/main/java/com/cos/cercat/search/TrendingKeyword.java
+++ b/cercat-domain/domain-search/src/main/java/com/cos/cercat/search/TrendingKeyword.java
@@ -7,4 +7,8 @@ public record TrendingKeyword(
     public static TrendingKeyword of(String keyword, KeywordStatus status) {
         return new TrendingKeyword(keyword, status);
     }
+
+    public static TrendingKeyword newKeyword(String keyword) {
+        return new TrendingKeyword(keyword, KeywordStatus.NEW);
+    }
 }

--- a/cercat-domain/domain-search/src/main/java/com/cos/cercat/search/TrendingKeywordRepository.java
+++ b/cercat-domain/domain-search/src/main/java/com/cos/cercat/search/TrendingKeywordRepository.java
@@ -1,10 +1,13 @@
 package com.cos.cercat.search;
 
+import com.cos.cercat.certificate.Certificate;
+import com.cos.cercat.certificate.TargetCertificate;
+
 import java.util.List;
 import java.util.Optional;
 
 public interface TrendingKeywordRepository {
-    void setTrendingKeywords(List<String> trendingKeywords);
+    void setTrendingKeywords(Certificate certificate, List<TrendingKeyword> trendingKeywords);
 
-    List<String> findTrendingKeywords();
+    List<TrendingKeyword> findTrendingKeywords(Certificate certificate);
 }

--- a/cercat-domain/domain-search/src/main/java/com/cos/cercat/search/TrendingKeywordsCacheManager.java
+++ b/cercat-domain/domain-search/src/main/java/com/cos/cercat/search/TrendingKeywordsCacheManager.java
@@ -1,5 +1,6 @@
 package com.cos.cercat.search;
 
+import com.cos.cercat.certificate.Certificate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,12 +12,12 @@ public class TrendingKeywordsCacheManager {
 
     private final TrendingKeywordRepository trendingKeywordRepository;
 
-    public void setTrendingKeywords(List<String> trendingKeywords) {
-        trendingKeywordRepository.setTrendingKeywords(trendingKeywords);
+    public void setTrendingKeywords(Certificate certificate, List<TrendingKeyword> trendingKeywords) {
+        trendingKeywordRepository.setTrendingKeywords(certificate, trendingKeywords);
     }
 
-    public List<String> findTrendingKeywords() {
-        return trendingKeywordRepository.findTrendingKeywords();
+    public List<TrendingKeyword> findTrendingKeywords(Certificate certificate) {
+        return trendingKeywordRepository.findTrendingKeywords(certificate);
     }
 
 }

--- a/cercat-storage/board-dataaccess/src/main/java/com/cos/cercat/domain/FavoriteBoardEntity.java
+++ b/cercat-storage/board-dataaccess/src/main/java/com/cos/cercat/domain/FavoriteBoardEntity.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Persistable;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "favorite_board")
 public class FavoriteBoardEntity extends BaseTimeEntity implements Persistable<FavoriteBoardPK> {

--- a/cercat-storage/search-dataaccess/build.gradle
+++ b/cercat-storage/search-dataaccess/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id 'org.jetbrains.kotlin.jvm'
+}
 bootJar {
     enabled = false
 }
@@ -11,13 +14,19 @@ dependencies {
     implementation project(':cercat-domain:domain-user');
     implementation project(':cercat-storage:post-dataaccess');
     implementation project(':cercat-storage:user-dataaccess');
+    implementation project(':cercat-storage:certificate-dataaccess');
     implementation project(':cercat-storage:jpa-dataaccess');
     implementation project(':cercat-storage:redis-dataaccess');
     implementation project(':cercat-storage:elasticsearch-dataaccess');
 
+    // shedlock - schedule lock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
+
     //elastic search
     api 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
     api 'co.elastic.clients:elasticsearch-java:8.9.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 bootJar {
@@ -40,4 +49,10 @@ sourceSets {
 // gradle clean 시에 QClass 디렉토리 삭제
 clean {
     delete file(generated)
+}
+repositories {
+    mavenCentral()
+}
+kotlin {
+    jvmToolchain(17)
 }

--- a/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/cache/TrendingKeywordCacheRepositoryImpl.java
+++ b/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/cache/TrendingKeywordCacheRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.cos.cercat.cache;
 
+import com.cos.cercat.certificate.Certificate;
+import com.cos.cercat.search.TrendingKeyword;
 import com.cos.cercat.search.TrendingKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,25 +9,30 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 @Slf4j
 public class TrendingKeywordCacheRepositoryImpl implements TrendingKeywordRepository {
 
-    private final static String TRENDING_KEYWORDS_KEY = "TRENDING_KEYWORDS";
-    private final RedisTemplate<String, List<String>> redisTemplate;
+    private final RedisTemplate<String, List<TrendingKeyword>> redisTemplate;
 
     @Override
-    public void setTrendingKeywords(List<String> trendingKeywords) {
-        redisTemplate.opsForValue().set(TRENDING_KEYWORDS_KEY, trendingKeywords);
+    public void setTrendingKeywords(Certificate certificate, List<TrendingKeyword> trendingKeywords) {
+        String key = getKey(certificate);
+        log.info("Set Trending Keywords {} : {}", key, trendingKeywords);
+        redisTemplate.opsForValue().set(key, trendingKeywords);
     }
 
     @Override
-    public List<String> findTrendingKeywords() {
-        List<String> trendingKeywords = redisTemplate.opsForValue().get(TRENDING_KEYWORDS_KEY);
-        log.info("Get Trending Keywords : {}", trendingKeywords);
+    public List<TrendingKeyword> findTrendingKeywords(Certificate certificate) {
+        String key = getKey(certificate);
+        List<TrendingKeyword> trendingKeywords = redisTemplate.opsForValue().get(key);
+        log.info("Get Trending Keywords {} : {}", key, trendingKeywords);
         return trendingKeywords;
+    }
+
+    private String getKey(Certificate certificate) {
+        return "CERTIFICATE_TRENDING:" + certificate.id();
     }
 }

--- a/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/config/SearchRedisConfig.java
+++ b/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/config/SearchRedisConfig.java
@@ -1,6 +1,9 @@
 package com.cos.cercat.config;
 
 import com.cos.cercat.search.SearchLog;
+import com.cos.cercat.search.TrendingKeyword;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -31,11 +34,12 @@ public class SearchRedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, List<String>> trendingKeywordRedisTemplate() {
-        RedisTemplate<String, List<String>> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, List<TrendingKeyword>> trendingKeywordRedisTemplate() {
+        RedisTemplate<String, List<TrendingKeyword>> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(List.class));
+        JavaType type = TypeFactory.defaultInstance().constructCollectionType(List.class, TrendingKeyword.class);
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(type));
         return redisTemplate;
     }
 

--- a/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/config/TrendingCacheScheduleConfig.java
+++ b/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/config/TrendingCacheScheduleConfig.java
@@ -1,0 +1,40 @@
+package com.cos.cercat.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30M")
+public class TrendingCacheScheduleConfig implements SchedulingConfigurer {
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(10);
+        scheduler.setThreadNamePrefix("scheduled-task-pool-");
+        scheduler.initialize();
+        taskRegistrar.setTaskScheduler(scheduler);
+    }
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withTableName("cercat_test.shedlock")
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
+    }
+}

--- a/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/repository/CustomPostSearchRepositoryImpl.java
+++ b/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/repository/CustomPostSearchRepositoryImpl.java
@@ -45,8 +45,8 @@ public class CustomPostSearchRepositoryImpl implements CustomPostSearchRepositor
     private final String KEYWORD_KEYWORD = "keyword.keyword";
     private final String KEYWORD_EDGE_NGRAM = "keyword.edge_ngram";
     private final String KEYWORD_NORI = "keyword.nori";
-    private final String URI_FIELD = "uri";
-    private final String URI_PREFIX = "/api/v1/certificates/";
+    private final String URI_KEYWORD = "uri.keyword";
+    private final String URI_PREFIX = "/api/v2/certificates/";
     private final String URI_SEARCH = "/search";
     private final String MINIMUM_SHOULD_MATCH = "1";
     private final String LOG_INDEX_PREFIX = "logstash-";
@@ -160,7 +160,7 @@ public class CustomPostSearchRepositoryImpl implements CustomPostSearchRepositor
     public List<String> getRecentTop10Keywords(Long certificateId) {
         ElasticsearchClient client = createElasticsearchClient();
 
-        Query query = createRecentTop5Query(certificateId);
+        Query query = createRecentTop10Query(certificateId);
 
         try {
             SearchResponse<Void> response = client.search(s -> s
@@ -182,9 +182,9 @@ public class CustomPostSearchRepositoryImpl implements CustomPostSearchRepositor
     private Query createAutoCompletedQuery(Long certificateId, String searchText) {
         return BoolQuery.of(b -> b
                 .filter(f -> f
-                        .match(m -> m
-                                .field(URI_FIELD)
-                                .query(URI_PREFIX + certificateId + URI_SEARCH)
+                        .term(m -> m
+                                .field(URI_KEYWORD)
+                                .value(URI_PREFIX + certificateId + URI_SEARCH)
                         )
                 ).must(m -> m.
                         bool(b1 -> b1
@@ -209,7 +209,7 @@ public class CustomPostSearchRepositoryImpl implements CustomPostSearchRepositor
         )._toQuery();
     }
 
-    private Query createRecentTop5Query(Long certificateId) {
+    private Query createRecentTop10Query(Long certificateId) {
         return BoolQuery.of(b -> b
 //                .filter(f -> f
 //                        .range(r -> r
@@ -219,9 +219,9 @@ public class CustomPostSearchRepositoryImpl implements CustomPostSearchRepositor
 //                        )
 //                ) // 유저수가 적어서 최근 2시간 검색어가 없을 수 있음 -> 향후 변경
                 .filter(f -> f
-                        .match(m -> m
-                                .field(URI_FIELD)
-                                .query(URI_PREFIX + certificateId + URI_SEARCH)
+                        .term(m -> m
+                                .field(URI_KEYWORD)
+                                .value(URI_PREFIX + certificateId + URI_SEARCH)
                         )
                 ))._toQuery();
     }

--- a/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/schedule/TrendingCacheSchedule.java
+++ b/cercat-storage/search-dataaccess/src/main/java/com/cos/cercat/schedule/TrendingCacheSchedule.java
@@ -1,0 +1,71 @@
+package com.cos.cercat.schedule;
+
+import com.cos.cercat.cache.TrendingKeywordCacheRepositoryImpl;
+import com.cos.cercat.certificate.Certificate;
+import com.cos.cercat.certificate.TargetCertificate;
+import com.cos.cercat.repository.CertificateRepositoryImpl;
+import com.cos.cercat.repository.PostForForSearchRepositoryImpl;
+import com.cos.cercat.search.KeywordStatus;
+import com.cos.cercat.search.TrendingKeyword;
+import com.cos.cercat.search.TrendingKeywordsCacheManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TrendingCacheSchedule {
+
+    private final PostForForSearchRepositoryImpl postForSearchRepository;
+    private final TrendingKeywordCacheRepositoryImpl trendingKeywordCacheRepository;
+    private final CertificateRepositoryImpl certificateRepository;
+
+    @Scheduled(cron = "0 */5 * * * *")
+    @SchedulerLock(name = "trending_cache", lockAtMostFor = "PT2S", lockAtLeastFor = "PT2S")
+    public void trendingCache() {
+        log.info("Trending Cache Scheduled task executed at {}", LocalDateTime.now());
+
+        List<Certificate> certificates = certificateRepository.findAll();
+
+        for (Certificate certificate : certificates) {
+            List<TrendingKeyword> trendingKeywords = new ArrayList<>();
+            List<String> currentKeywords = postForSearchRepository.findRecentTop10Keywords(certificate);
+            List<TrendingKeyword> beforeKeywords = trendingKeywordCacheRepository.findTrendingKeywords(certificate);
+
+            for (String currentKeyword : currentKeywords) {
+                KeywordStatus status = getKeywordStatus(beforeKeywords, currentKeywords, currentKeyword);
+                trendingKeywords.add(TrendingKeyword.of(currentKeyword, status));
+            }
+            trendingKeywordCacheRepository.setTrendingKeywords(certificate, trendingKeywords);
+        }
+    }
+
+    private KeywordStatus getKeywordStatus(List<TrendingKeyword> beforeTrendingWithStatus,
+                                           List<String> currentKeywords,
+                                           String currentKeyword) {
+
+        if (beforeTrendingWithStatus == null || beforeTrendingWithStatus.stream().noneMatch(t -> t.keyword().equals(currentKeyword))) {
+            return KeywordStatus.NEW;
+        }
+
+        int currentRank = currentKeywords.indexOf(currentKeyword);
+        int beforeRank = beforeTrendingWithStatus.stream().map(TrendingKeyword::keyword).toList().indexOf(currentKeyword);
+
+        if (currentRank > beforeRank) {
+            return KeywordStatus.RANK_DOWN;
+        }
+
+        if (currentRank < beforeRank) {
+            return KeywordStatus.RANK_UP;
+        }
+        return KeywordStatus.UNCHANGED;
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,11 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version '1.9.23'
+    }
+}
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.5.0'
+}
 rootProject.name = 'cercat'
 include('cercat-application')
 include('cercat-application:app-api')


### PR DESCRIPTION
- 실시간 검색어 캐싱 적용
- 멀티 서버에서도 한번만 동작하도록 shed lock 적용

<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

매 5분마다 스케쥴링을 돌면서 ES에서 실시간 검색어를 불러와 Redis의 실시간 검색어 캐싱 갱신
사용자는 redis에서만 실시간 검색어 조회 -> 모든 요청마다 캐싱/갱신을 하고있던 애초에 설계가 잘못됨

멀티서버에서도 Spring 스케쥴러가 한번만 동작하도록 Database ShedLock  2초간 적용

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
