### PR TITLE
[#39] [FEATURE] Create Mock Exam API for admin

### DIFF
--- a/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/api/MockExamApi.java
+++ b/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/api/MockExamApi.java
@@ -1,20 +1,17 @@
 package com.cos.cercat.apis.mockExam.api;
 
-import com.cos.cercat.apis.mockExam.request.CreateQuestionRequest;
-import com.cos.cercat.mockexam.MockExamInfo;
+import com.cos.cercat.apis.mockExam.request.CreateMockExamRequest;
 import com.cos.cercat.apis.mockExam.response.MockExamResponse;
 import com.cos.cercat.apis.mockExam.response.QuestionResponse;
 import com.cos.cercat.certificate.TargetCertificate;
 import com.cos.cercat.common.domain.Response;
 import com.cos.cercat.mockexam.MockExamService;
+import com.cos.cercat.mockexam.MockExamSession;
 import com.cos.cercat.mockexam.TargetMockExam;
 import com.cos.cercat.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -53,11 +50,16 @@ public class MockExamApi implements MockExamApiDocs {
     }
 
     @Override
+    @PostMapping("/mock-exams/{certificateId}")
     public Response<Void> createMockExam(@PathVariable Long certificateId,
-                                         MockExamInfo mockExamInfo,
-                                         CreateQuestionRequest questionRequest) {
+                                         CreateMockExamRequest request) {
+        mockExamService.createMockExam(
+                TargetCertificate.from(certificateId),
+                MockExamSession.of(request.examYear(), request.round()),
+                request.timeLimit(),
+                request.toNewQuestions()
+        );
 
-        mockExamService.createMockExam(TargetCertificate.from(certificateId), mockExamInfo, questionRequest.questions());
         return Response.success("모의고사 생성 성공");
     }
 }

--- a/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/api/MockExamApi.java
+++ b/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/api/MockExamApi.java
@@ -6,7 +6,6 @@ import com.cos.cercat.apis.mockExam.response.QuestionResponse;
 import com.cos.cercat.certificate.TargetCertificate;
 import com.cos.cercat.common.domain.Response;
 import com.cos.cercat.mockexam.MockExamService;
-import com.cos.cercat.mockexam.MockExamSession;
 import com.cos.cercat.mockexam.TargetMockExam;
 import com.cos.cercat.user.User;
 import lombok.RequiredArgsConstructor;
@@ -52,12 +51,12 @@ public class MockExamApi implements MockExamApiDocs {
     @Override
     @PostMapping("/mock-exams/{certificateId}")
     public Response<Void> createMockExam(@PathVariable Long certificateId,
-                                         CreateMockExamRequest request) {
+                                         @RequestBody CreateMockExamRequest request) {
         mockExamService.createMockExam(
                 TargetCertificate.from(certificateId),
-                MockExamSession.of(request.examYear(), request.round()),
+                request.toSession(),
                 request.timeLimit(),
-                request.toNewQuestions()
+                request.toContent()
         );
 
         return Response.success("모의고사 생성 성공");

--- a/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/api/MockExamApiDocs.java
+++ b/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/api/MockExamApiDocs.java
@@ -1,6 +1,6 @@
 package com.cos.cercat.apis.mockExam.api;
 
-import com.cos.cercat.apis.mockExam.request.CreateQuestionRequest;
+import com.cos.cercat.apis.mockExam.request.CreateMockExamRequest;
 import com.cos.cercat.mockexam.MockExamInfo;
 import com.cos.cercat.apis.mockExam.response.MockExamResponse;
 import com.cos.cercat.apis.mockExam.response.QuestionResponse;
@@ -28,8 +28,7 @@ public interface MockExamApiDocs {
 
     @Operation(summary = "모의고사 만들기")
     Response<Void> createMockExam(@PathVariable Long certificateId,
-                                  MockExamInfo mockExamInfo,
-                                  CreateQuestionRequest questionRequest);
+                                  CreateMockExamRequest request);
 
 
 

--- a/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/api/MockExamApiDocs.java
+++ b/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/api/MockExamApiDocs.java
@@ -1,7 +1,6 @@
 package com.cos.cercat.apis.mockExam.api;
 
 import com.cos.cercat.apis.mockExam.request.CreateMockExamRequest;
-import com.cos.cercat.mockexam.MockExamInfo;
 import com.cos.cercat.apis.mockExam.response.MockExamResponse;
 import com.cos.cercat.apis.mockExam.response.QuestionResponse;
 import com.cos.cercat.common.domain.Response;

--- a/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/request/CreateMockExamRequest.java
+++ b/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/request/CreateMockExamRequest.java
@@ -1,0 +1,20 @@
+package com.cos.cercat.apis.mockExam.request;
+
+
+import com.cos.cercat.mockexam.NewQuestion;
+
+import java.util.List;
+
+public record CreateMockExamRequest(
+        Integer examYear,
+        Integer round,
+        List<CreateQuestionRequest> questions,
+        Long timeLimit,
+        Integer score
+) {
+    public List<NewQuestion> toNewQuestions() {
+        return questions.stream()
+                .map(question -> question.toNewQuestion(score))
+                .toList();
+    }
+}

--- a/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/request/CreateMockExamRequest.java
+++ b/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/request/CreateMockExamRequest.java
@@ -1,7 +1,8 @@
 package com.cos.cercat.apis.mockExam.request;
 
 
-import com.cos.cercat.mockexam.NewQuestion;
+import com.cos.cercat.mockexam.MockExamSession;
+import com.cos.cercat.mockexam.QuestionWithSubjectSeq;
 
 import java.util.List;
 
@@ -12,9 +13,14 @@ public record CreateMockExamRequest(
         Long timeLimit,
         Integer score
 ) {
-    public List<NewQuestion> toNewQuestions() {
+
+    public MockExamSession toSession() {
+        return new MockExamSession(examYear, round);
+    }
+
+    public List<QuestionWithSubjectSeq> toContent() {
         return questions.stream()
-                .map(question -> question.toNewQuestion(score))
+                .map(question -> question.toQuestionWithSubjectSeq(score))
                 .toList();
     }
 }

--- a/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/request/CreateQuestionRequest.java
+++ b/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/request/CreateQuestionRequest.java
@@ -1,11 +1,31 @@
 package com.cos.cercat.apis.mockExam.request;
 
+import com.cos.cercat.mockexam.NewQuestion;
+import com.cos.cercat.mockexam.QuestionContent;
+import com.cos.cercat.mockexam.QuestionOption;
+
 import java.util.List;
-import java.util.Map;
 
 public record CreateQuestionRequest(
-        String examYear,
-        String round,
-        Map<String, List<String>> questions
+        Integer subjectSeq,
+        Integer questionNumber,
+        String question,
+        List<String> choices,
+        Integer answer
 ) {
+    public NewQuestion toNewQuestion(int score) {
+        return new NewQuestion(
+                subjectSeq,
+                QuestionContent.of(
+                        questionNumber,
+                        question,
+                        answer,
+                        null,
+                        choices.stream()
+                                .map((choice) -> QuestionOption.of(choices.indexOf(choice), choice, null))
+                                .toList(),
+                        score
+                )
+        );
+    }
 }

--- a/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/request/CreateQuestionRequest.java
+++ b/cercat-application/app-api/src/main/java/com/cos/cercat/apis/mockExam/request/CreateQuestionRequest.java
@@ -1,8 +1,8 @@
 package com.cos.cercat.apis.mockExam.request;
 
-import com.cos.cercat.mockexam.NewQuestion;
 import com.cos.cercat.mockexam.QuestionContent;
 import com.cos.cercat.mockexam.QuestionOption;
+import com.cos.cercat.mockexam.QuestionWithSubjectSeq;
 
 import java.util.List;
 
@@ -13,8 +13,8 @@ public record CreateQuestionRequest(
         List<String> choices,
         Integer answer
 ) {
-    public NewQuestion toNewQuestion(int score) {
-        return new NewQuestion(
+    public QuestionWithSubjectSeq toQuestionWithSubjectSeq(int score) {
+        return new QuestionWithSubjectSeq(
                 subjectSeq,
                 QuestionContent.of(
                         questionNumber,
@@ -22,7 +22,7 @@ public record CreateQuestionRequest(
                         answer,
                         null,
                         choices.stream()
-                                .map((choice) -> QuestionOption.of(choices.indexOf(choice), choice, null))
+                                .map((choice) -> QuestionOption.of(choices.indexOf(choice) + 1, choice, null))
                                 .toList(),
                         score
                 )

--- a/cercat-domain/domain-certificate/src/main/java/com/cos/cercat/certificate/Subject.java
+++ b/cercat-domain/domain-certificate/src/main/java/com/cos/cercat/certificate/Subject.java
@@ -1,7 +1,7 @@
 package com.cos.cercat.certificate;
 
 public record Subject(
-        long subjectId,
+        Long subjectId,
         Certificate certificate,
         SubjectInfo subjectInfo
 ) {

--- a/cercat-domain/domain-certificate/src/main/java/com/cos/cercat/certificate/SubjectFinder.java
+++ b/cercat-domain/domain-certificate/src/main/java/com/cos/cercat/certificate/SubjectFinder.java
@@ -3,7 +3,6 @@ package com.cos.cercat.certificate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Comparator;
 import java.util.List;
 
 @Component
@@ -13,10 +12,7 @@ public class SubjectFinder {
     private final CertificateRepository certificateRepository;
 
     public List<Subject> find(Certificate certificate) {
-        List<Subject> subjects = certificateRepository.findSubject(certificate);
-        subjects.sort(Comparator.comparing(subject -> subject.subjectInfo().subjectSequence()));
-
-        return subjects;
+        return certificateRepository.findSubject(certificate);
     }
 
 }

--- a/cercat-domain/domain-certificate/src/main/java/com/cos/cercat/certificate/SubjectFinder.java
+++ b/cercat-domain/domain-certificate/src/main/java/com/cos/cercat/certificate/SubjectFinder.java
@@ -3,6 +3,7 @@ package com.cos.cercat.certificate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Component
@@ -12,7 +13,10 @@ public class SubjectFinder {
     private final CertificateRepository certificateRepository;
 
     public List<Subject> find(Certificate certificate) {
-        return certificateRepository.findSubject(certificate);
+        List<Subject> subjects = certificateRepository.findSubject(certificate);
+        subjects.sort(Comparator.comparing(subject -> subject.subjectInfo().subjectSequence()));
+
+        return subjects;
     }
 
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExam.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExam.java
@@ -9,4 +9,7 @@ public record MockExam(
         long timeLimit,
         Certificate certificate
 ) {
+    public static MockExam of(TargetMockExam targetMockExam, NewMockExam newMockExam) {
+        return new MockExam(targetMockExam.mockExamId(), newMockExam.session(), newMockExam.timeLimit(), newMockExam.certificate());
+    }
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamAppender.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamAppender.java
@@ -1,0 +1,28 @@
+package com.cos.cercat.mockexam;
+
+import com.cos.cercat.certificate.Certificate;
+import com.cos.cercat.certificate.SubjectFinder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MockExamAppender {
+
+    private final MockExamRepository mockExamRepository;
+    private final SubjectFinder subjectFinder;
+
+    public TargetMockExam append(Certificate certificate,
+                                 MockExamSession session,
+                                 Long timeLimit,
+                                 List<NewQuestion> newQuestions) {
+        NewMockExam newMockExam = NewMockExam.of(session, timeLimit, certificate);
+        TargetMockExam targetMockExam = mockExamRepository.save(newMockExam);
+
+        mockExamRepository.saveQuestions(MockExam.of(targetMockExam, newMockExam), newQuestions);
+        return null;
+    }
+
+}

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamAppender.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamAppender.java
@@ -1,6 +1,7 @@
 package com.cos.cercat.mockexam;
 
 import com.cos.cercat.certificate.Certificate;
+import com.cos.cercat.certificate.Subject;
 import com.cos.cercat.certificate.SubjectFinder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,12 +18,18 @@ public class MockExamAppender {
     public TargetMockExam append(Certificate certificate,
                                  MockExamSession session,
                                  Long timeLimit,
-                                 List<NewQuestion> newQuestions) {
+                                 List<QuestionWithSubjectSeq> contents) {
         NewMockExam newMockExam = NewMockExam.of(session, timeLimit, certificate);
         TargetMockExam targetMockExam = mockExamRepository.save(newMockExam);
 
-        mockExamRepository.saveQuestions(MockExam.of(targetMockExam, newMockExam), newQuestions);
-        return null;
+        List<Subject> subjects = subjectFinder.find(certificate);
+
+        List<NewQuestion> newQuestions = contents.stream()
+                .map(content -> content.toNewQuestion(subjects))
+                .toList();
+
+        mockExamRepository.saveQuestions(targetMockExam, newQuestions);
+        return targetMockExam;
     }
 
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamInfo.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamInfo.java
@@ -1,7 +1,0 @@
-package com.cos.cercat.mockexam;
-
-public record MockExamInfo(
-        Integer examYear,
-        Integer round
-) {
-}

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamRepository.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamRepository.java
@@ -6,6 +6,9 @@ import com.cos.cercat.certificate.Certificate;
 import java.util.List;
 
 public interface MockExamRepository {
+
+    TargetMockExam save(NewMockExam newMockExam);
+
     Question readQuestion(Certificate certificate,
                           MockExamSession mockExamSession,
                           int questionSequence);
@@ -17,4 +20,6 @@ public interface MockExamRepository {
     List<Integer> findExamYears(Certificate certificate);
 
     MockExam read(TargetMockExam targetMockExam);
+
+    void saveQuestions(MockExam of, List<NewQuestion> newQuestions);
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamRepository.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamRepository.java
@@ -21,5 +21,5 @@ public interface MockExamRepository {
 
     MockExam read(TargetMockExam targetMockExam);
 
-    void saveQuestions(MockExam of, List<NewQuestion> newQuestions);
+    void saveQuestions(TargetMockExam targetMockExam, List<NewQuestion> newQuestions);
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamService.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamService.java
@@ -37,8 +37,8 @@ public class MockExamService {
     public void createMockExam(TargetCertificate targetCertificate,
                                MockExamSession session,
                                Long timeLimit,
-                               List<NewQuestion> newQuestions) {
+                               List<QuestionWithSubjectSeq> contents) {
         Certificate certificate = certificateReader.read(targetCertificate);
-        mockExamAppender.append(certificate, session, timeLimit, newQuestions);
+        mockExamAppender.append(certificate, session, timeLimit, contents);
     }
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamService.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/MockExamService.java
@@ -7,13 +7,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class MockExamService {
 
     private final MockExamFinder mockExamFinder;
+    private final MockExamAppender mockExamAppender;
     private final QuestionFinder questionFinder;
     private final CertificateReader certificateReader;
     private final MockExamReader mockExamReader;
@@ -34,10 +34,11 @@ public class MockExamService {
         return questionFinder.find(mockExam);
     }
 
-    public void createMockExam(TargetCertificate target,
-                               MockExamInfo mockExamInfo,
-                               Map<String, List<String>> questions) {
-
-
+    public void createMockExam(TargetCertificate targetCertificate,
+                               MockExamSession session,
+                               Long timeLimit,
+                               List<NewQuestion> newQuestions) {
+        Certificate certificate = certificateReader.read(targetCertificate);
+        mockExamAppender.append(certificate, session, timeLimit, newQuestions);
     }
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/NewMockExam.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/NewMockExam.java
@@ -1,0 +1,14 @@
+package com.cos.cercat.mockexam;
+
+import com.cos.cercat.certificate.Certificate;
+
+public record NewMockExam(
+        MockExamSession session,
+        Long timeLimit,
+        Certificate certificate
+) {
+
+    public static NewMockExam of(MockExamSession session, Long timeLimit, Certificate certificate) {
+        return new NewMockExam(session, timeLimit, certificate);
+    }
+}

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/NewQuestion.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/NewQuestion.java
@@ -1,7 +1,11 @@
 package com.cos.cercat.mockexam;
 
+import com.cos.cercat.certificate.Subject;
+
 public record NewQuestion(
-        Integer subjectSeq,
+        Subject subject,
         QuestionContent questionContent
 ) {
+
+
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/NewQuestion.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/NewQuestion.java
@@ -1,0 +1,7 @@
+package com.cos.cercat.mockexam;
+
+public record NewQuestion(
+        Integer subjectSeq,
+        QuestionContent questionContent
+) {
+}

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/Question.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/Question.java
@@ -4,7 +4,7 @@ package com.cos.cercat.mockexam;
 import com.cos.cercat.certificate.Subject;
 
 public record Question(
-        long id,
+        Long id,
         MockExam mockExam,
         Subject subject,
         QuestionContent questionContent

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/QuestionContent.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/QuestionContent.java
@@ -12,4 +12,19 @@ public record QuestionContent(
         List<QuestionOption> questionOptions,
         int score
 ) {
+    public static QuestionContent of(int questionSequence,
+                                     String questionText,
+                                     int correctOption,
+                                     Image questionImage,
+                                     List<QuestionOption> questionOptions,
+                                     int score) {
+        return new QuestionContent(
+                questionSequence,
+                questionText,
+                correctOption,
+                questionImage,
+                questionOptions,
+                score
+        );
+    }
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/QuestionOption.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/QuestionOption.java
@@ -5,4 +5,7 @@ public record QuestionOption(
         String optionText,
         String optionImageUrl
 ) {
+    public static QuestionOption of(int optionSequence, String optionText, String optionImageUrl) {
+        return new QuestionOption(optionSequence, optionText, optionImageUrl);
+    }
 }

--- a/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/QuestionWithSubjectSeq.java
+++ b/cercat-domain/domain-mockexam/src/main/java/com/cos/cercat/mockexam/QuestionWithSubjectSeq.java
@@ -1,0 +1,23 @@
+package com.cos.cercat.mockexam;
+
+import com.cos.cercat.certificate.Subject;
+
+import java.util.List;
+
+public record QuestionWithSubjectSeq(
+        Integer subjectSeq,
+        QuestionContent questionContent
+) {
+
+    public NewQuestion toNewQuestion(List<Subject> subjectList) {
+        Subject matchingSubject = findMatchingSubject(subjectList);
+        return new NewQuestion(matchingSubject, questionContent);
+    }
+
+    private Subject findMatchingSubject(List<Subject> subjectList) {
+        return subjectList.stream()
+                .filter(subject -> subject.subjectInfo().subjectSequence().equals(subjectSeq))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/cercat-domain/domain-mockexamresult/src/main/java/com/cos/cercat/mockexamresult/CreateMockExamResultService.java
+++ b/cercat-domain/domain-mockexamresult/src/main/java/com/cos/cercat/mockexamresult/CreateMockExamResultService.java
@@ -16,7 +16,6 @@ import java.util.List;
 public class CreateMockExamResultService {
 
     private final MockExamResultAppender mockExamResultAppender;
-    private final MockExamResultReader mockExamResultReader;
     private final UserReader userReader;
     private final MockExamReader mockExamReader;
 

--- a/cercat-storage/certificate-dataaccess/src/main/java/com/cos/cercat/repository/CertificateRepositoryImpl.java
+++ b/cercat-storage/certificate-dataaccess/src/main/java/com/cos/cercat/repository/CertificateRepositoryImpl.java
@@ -7,11 +7,13 @@ import com.cos.cercat.domain.CertificateEntity;
 import com.cos.cercat.domain.SubjectEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
+@Transactional
 public class CertificateRepositoryImpl implements CertificateRepository {
 
     private final CertificateJpaRepository certificateJpaRepository;

--- a/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/domain/MockExamEntity.java
+++ b/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/domain/MockExamEntity.java
@@ -4,6 +4,8 @@ import com.cos.cercat.dto.MockExamDTO;
 import com.cos.cercat.entity.BaseTimeEntity;
 import com.cos.cercat.mockexam.MockExam;
 import com.cos.cercat.mockexam.MockExamSession;
+import com.cos.cercat.mockexam.NewMockExam;
+import com.cos.cercat.mockexam.TargetMockExam;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,6 +47,21 @@ public class MockExamEntity extends BaseTimeEntity {
                 .timeLimit(timeLimit)
                 .totalScore(totalScore)
                 .certificateEntity(dto.certificateDTO().toEntity())
+                .build();
+    }
+
+    public static MockExamEntity from(NewMockExam newMockExam) {
+        return MockExamEntity.builder()
+                .examYear(newMockExam.session().examYear())
+                .round(newMockExam.session().round())
+                .timeLimit(newMockExam.timeLimit())
+                .certificateEntity(CertificateEntity.from(newMockExam.certificate()))
+                .build();
+    }
+
+    public static MockExamEntity from(TargetMockExam targetMockExam) {
+        return MockExamEntity.builder()
+                .id(targetMockExam.mockExamId())
                 .build();
     }
 

--- a/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/domain/QuestionEntity.java
+++ b/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/domain/QuestionEntity.java
@@ -2,8 +2,10 @@ package com.cos.cercat.domain;
 
 import com.cos.cercat.entity.ImageEntity;
 import com.cos.cercat.domain.embededId.QuestionOptionPK;
+import com.cos.cercat.mockexam.NewQuestion;
 import com.cos.cercat.mockexam.Question;
 import com.cos.cercat.mockexam.QuestionContent;
+import com.cos.cercat.mockexam.TargetMockExam;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
@@ -18,6 +20,7 @@ import java.util.regex.Matcher;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Table(
         name = "question",
         indexes = @Index(name = "idx_question_seq", columnList = "question_seq")
@@ -48,6 +51,7 @@ public class QuestionEntity {
 
     private int questionSeq;
 
+    @Column(length = 1000)
     private String questionText;
 
     @OneToMany(mappedBy = "questionEntity", cascade = CascadeType.ALL)
@@ -83,6 +87,25 @@ public class QuestionEntity {
         return new QuestionEntity(
                 mockExamEntity
         );
+    }
+
+    public static QuestionEntity from(TargetMockExam targetMockExam, NewQuestion newQuestion) {
+        QuestionEntity questionEntity = QuestionEntity.builder()
+                .mockExamEntity(MockExamEntity.from(targetMockExam))
+                .subjectEntity(SubjectEntity.from(newQuestion.subject()))
+                .questionSeq(newQuestion.questionContent().questionSequence())
+                .questionText(newQuestion.questionContent().questionText())
+                .questionOptions(new ArrayList<>())
+                .correctOption(newQuestion.questionContent().correctOption())
+                .score(newQuestion.questionContent().score())
+                .build();
+
+        questionEntity.getQuestionOptions().addAll(
+                newQuestion.questionContent().questionOptions().stream()
+                        .map(questionOption -> QuestionOptionEntity.from(questionEntity, questionOption))
+                        .toList()
+        );
+        return questionEntity;
     }
 
     public static QuestionEntity from(Question question) {

--- a/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/domain/QuestionOptionEntity.java
+++ b/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/domain/QuestionOptionEntity.java
@@ -53,4 +53,11 @@ public class QuestionOptionEntity {
     }
 
 
+    public static QuestionOptionEntity from(QuestionEntity question, QuestionOption questionOption) {
+        return QuestionOptionEntity.builder()
+                .questionOptionPK(QuestionOptionPK.from(questionOption.optionSequence()))
+                .questionEntity(question)
+                .optionContent(questionOption.optionText())
+                .build();
+    }
 }

--- a/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/repository/MockExamRepositoryImpl.java
+++ b/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/repository/MockExamRepositoryImpl.java
@@ -21,6 +21,11 @@ public class MockExamRepositoryImpl implements MockExamRepository {
     private final MockExamJpaRepository mockExamJpaRepository;
 
     @Override
+    public TargetMockExam save(NewMockExam newMockExam) {
+        return null;
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public Question readQuestion(Certificate certificate,
                                  MockExamSession mockExamSession,

--- a/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/repository/MockExamRepositoryImpl.java
+++ b/cercat-storage/mockexam-dataaccess/src/main/java/com/cos/cercat/repository/MockExamRepositoryImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
+@Transactional
 public class MockExamRepositoryImpl implements MockExamRepository {
 
     private final QuestionJpaRepository questionJpaRepository;
@@ -22,7 +23,18 @@ public class MockExamRepositoryImpl implements MockExamRepository {
 
     @Override
     public TargetMockExam save(NewMockExam newMockExam) {
-        return null;
+        MockExamEntity entity = mockExamJpaRepository.save(MockExamEntity.from(newMockExam));
+        return TargetMockExam.from(entity.getId());
+    }
+
+    @Override
+    public void saveQuestions(TargetMockExam targetMockExam, List<NewQuestion> newQuestions) {
+
+        List<QuestionEntity> questionEntities = newQuestions.stream()
+                .map(newQuestion -> QuestionEntity.from(targetMockExam, newQuestion))
+                .toList();
+
+        questionJpaRepository.saveAll(questionEntities);
     }
 
     @Override


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

과목 순서를 통해 모의 고사와 문제들의 정보를 json으로 입력받아 해당 자격증의 과목순서를 통해 id로 매핑하고 저장

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
